### PR TITLE
MapElements usage

### DIFF
--- a/src/main/java/com/mehmandarov/beam/OsloCityBikeBasic.java
+++ b/src/main/java/com/mehmandarov/beam/OsloCityBikeBasic.java
@@ -8,6 +8,7 @@ import org.apache.beam.sdk.options.*;
 import org.apache.beam.sdk.transforms.*;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,15 +53,6 @@ public class OsloCityBikeBasic {
             }
         }
     }
-
-    /** A SimpleFunction that attempts to convert any objects into a printable string. */
-    public static class FormatAnythingAsTextFn extends SimpleFunction<Object, String> {
-        @Override
-        public String apply(Object input) {
-            return input.toString();
-        }
-    }
-
 
     /**
      * A PTransform that converts a PCollection containing lines of text into a PCollection of
@@ -127,7 +119,7 @@ public class OsloCityBikeBasic {
                 .apply("ReadLines: StationMetadataInputFiles", TextIO.read().from(options.getStationMetadataInputFile()))
                 .apply(new StationMetadata());
 
-        stationMetadata.apply(MapElements.via(new FormatAnythingAsTextFn()))
+        stationMetadata.apply(MapElements.into(TypeDescriptor.of(String.class)).via(o -> o.toString()))
                 .apply("WriteStationMetaData", TextIO.write().to(options.getMetadataOutput()));
         // RETURNS:
         // KV{157, {id=157, in_service=true, title=Nylandsveien, subtitle=mellom Norbygata og Urtegata, number_of_locks=30, station_center_lat=59.91562, station_center_lon=10.762248}}


### PR DESCRIPTION
MapElements is very useful for simple operations that can easily be
expressed in lamdas. Your example is better expressed in a lamda as it's
so small. If it's big, you can better create a DoFn.